### PR TITLE
Bring user upload buckets and associated user/policies under terraform management

### DIFF
--- a/terraform/modules/psd/data.tf
+++ b/terraform/modules/psd/data.tf
@@ -1,7 +1,0 @@
-data "aws_iam_user" "iam_user" {
-  user_name = var.iam_user_name
-}
-
-data "aws_s3_bucket" "user_uploads" {
-  bucket = var.user_uploads_bucket_name
-}

--- a/terraform/modules/psd/iam.tf
+++ b/terraform/modules/psd/iam.tf
@@ -14,14 +14,14 @@ resource "aws_iam_role" "extract_batch_operations" {
 }
 POLICY
 
-  description          = "Used by S3 Batch Operations to copy files extracted files from ${data.aws_s3_bucket.user_uploads.id} to the ${aws_s3_bucket.extract_files.id} S3 buckets"
+  description          = "Used by S3 Batch Operations to copy files extracted files from ${aws_s3_bucket.user_uploads.id} to the ${aws_s3_bucket.extract_files.id} S3 buckets"
   max_session_duration = "3600"
   name                 = var.extract_batch_operations_role_name
   path                 = "/"
 }
 
 resource "aws_iam_policy" "extract_batch_operations" {
-  description = "Allows objects to be copied from the ${data.aws_s3_bucket.user_uploads.id} to the ${aws_s3_bucket.extract_files.id} S3 buckets by the role S3 Batch Operations assumes"
+  description = "Allows objects to be copied from the ${aws_s3_bucket.user_uploads.id} to the ${aws_s3_bucket.extract_files.id} S3 buckets by the role S3 Batch Operations assumes"
   name        = var.extract_batch_operations_policy_name
   path        = "/"
 
@@ -31,7 +31,7 @@ resource "aws_iam_policy" "extract_batch_operations" {
     {
       "Action": "s3:GetObject",
       "Effect": "Allow",
-      "Resource": "${data.aws_s3_bucket.user_uploads.arn}/*",
+      "Resource": "${aws_s3_bucket.user_uploads.arn}/*",
       "Sid": "VisualEditor0"
     },
     {
@@ -91,5 +91,41 @@ POLICY
 
 resource "aws_iam_user_policy_attachment" "extract_batch_operation_trigger" {
   policy_arn = aws_iam_policy.extract_batch_operation_trigger.arn
-  user       = data.aws_iam_user.iam_user.user_name
+  user       = aws_iam_user.iam_user.name
+}
+
+resource "aws_iam_policy" "manage_user_upload_bucket_policy" {
+  name = var.manage_user_upload_bucket_policy_name
+  path = "/"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Sid": "VisualEditor0",
+          "Effect": "Allow",
+          "Action": [
+              "s3:PutObject",
+              "s3:GetObject",
+              "s3:ListBucket",
+              "s3:DeleteObject"
+          ],
+          "Resource": [
+              "${aws_s3_bucket.user_uploads.arn}/*",
+              "${aws_s3_bucket.user_uploads.arn}"
+          ]
+      }
+  ]
+}
+  POLICY
+}
+
+resource "aws_iam_user" "iam_user" {
+  name = var.iam_user_name
+}
+
+resource "aws_iam_user_policy_attachment" "manage_user_upload_bucket_policy" {
+  user       = aws_iam_user.iam_user.name
+  policy_arn = aws_iam_policy.manage_user_upload_bucket_policy.arn
 }

--- a/terraform/modules/psd/s3_buckets.tf
+++ b/terraform/modules/psd/s3_buckets.tf
@@ -7,3 +7,8 @@ resource "aws_s3_bucket" "extract_database_dumps" {
   bucket        = var.extract_database_dumps_bucket_name
   force_destroy = "false"
 }
+
+resource "aws_s3_bucket" "user_uploads" {
+  bucket = var.user_uploads_bucket_name
+  force_destroy = "false"
+}

--- a/terraform/modules/psd/variables.tf
+++ b/terraform/modules/psd/variables.tf
@@ -53,3 +53,11 @@ variable "extract_batch_operations_policy_name" {
   nullable    = false
   sensitive   = false
 }
+
+variable "manage_user_upload_bucket_policy_name" {
+  type        = string
+  description = "The name of the policy which permits management of the user upload bucket"
+  default     = "psd-user-upload-bucket-policy"
+  nullable    = false
+  sensitive   = false
+}

--- a/terraform/psd.tf
+++ b/terraform/psd.tf
@@ -20,6 +20,7 @@ module "psd_prod" {
   extract_batch_operations_role_name          = local.psd_config.prod.extract_batch_operations_role_name
   extract_batch_operation_trigger_policy_name = local.psd_config.prod.extract_batch_operation_trigger_policy_name
   extract_batch_operations_policy_name        = local.psd_config.prod.extract_batch_operations_policy_name
+  manage_user_upload_bucket_policy_name       = local.psd_config.prod.manage_user_upload_bucket_policy_name
 }
 
 module "psd_staging" {
@@ -32,4 +33,5 @@ module "psd_staging" {
   extract_batch_operations_role_name          = local.psd_config.staging.extract_batch_operations_role_name
   extract_batch_operation_trigger_policy_name = local.psd_config.staging.extract_batch_operation_trigger_policy_name
   extract_batch_operations_policy_name        = local.psd_config.staging.extract_batch_operations_policy_name
+  manage_user_upload_bucket_policy_name       = local.psd_config.staging.manage_user_upload_bucket_policy_name
 }


### PR DESCRIPTION
https://trello.com/c/Ji7sjJOi/1421-import-the-psd-user-uploads-s3-buckets-and-their-iam-policies-into-terraform

This PR follows on from the work done in [this previously merged PR](https://github.com/UKGovernmentBEIS/beis-opss-infrastructure/pull/10) brings the user upload buckets, as well as the associated iam users and policies under terraform management.

As noted in the trello ticket this should be deployed out of hours.